### PR TITLE
fix: default query flags

### DIFF
--- a/_cosmosvendor/patches/0005-Hack-make-AddQueryFlagsToCmd-and-AddTxFlagsToCmd-var.patch
+++ b/_cosmosvendor/patches/0005-Hack-make-AddQueryFlagsToCmd-and-AddTxFlagsToCmd-var.patch
@@ -1,0 +1,35 @@
+From fd347c6e2daefcb794da9d7b86d179d81dea6472 Mon Sep 17 00:00:00 2001
+From: Andrew Gouin <andrew@gouin.io>
+Date: Fri, 25 Oct 2024 13:58:58 -0600
+Subject: [PATCH] Hack: make AddQueryFlagsToCmd and AddTxFlagsToCmd vars so
+ they can be overridden
+
+---
+ client/flags/flags.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/client/flags/flags.go b/client/flags/flags.go
+index d44ed31679..b01790f95f 100644
+--- a/client/flags/flags.go
++++ b/client/flags/flags.go
+@@ -103,7 +103,7 @@ const (
+ var LineBreak = &cobra.Command{Run: func(*cobra.Command, []string) {}}
+ 
+ // AddQueryFlagsToCmd adds common flags to a module query command.
+-func AddQueryFlagsToCmd(cmd *cobra.Command) {
++var AddQueryFlagsToCmd = func(cmd *cobra.Command) {
+ 	cmd.Flags().String(FlagNode, "tcp://localhost:26657", "<host>:<port> to CometBFT RPC interface for this chain")
+ 	cmd.Flags().String(FlagGRPC, "", "the gRPC endpoint to use for this chain")
+ 	cmd.Flags().Bool(FlagGRPCInsecure, false, "allow gRPC over insecure channels, if not the server must use TLS")
+@@ -116,7 +116,7 @@ func AddQueryFlagsToCmd(cmd *cobra.Command) {
+ }
+ 
+ // AddTxFlagsToCmd adds common flags to a module tx command.
+-func AddTxFlagsToCmd(cmd *cobra.Command) {
++var AddTxFlagsToCmd = func(cmd *cobra.Command) {
+ 	f := cmd.Flags()
+ 	f.StringP(FlagOutput, "o", OutputFormatJSON, "Output format (text|json)")
+ 	if cmd.Flag(FlagFrom) == nil { // avoid flag redefinition when it's already been added by AutoCLI
+-- 
+2.47.0
+

--- a/internal/gci/command.go
+++ b/internal/gci/command.go
@@ -17,6 +17,7 @@ import (
 	simdcmd "cosmossdk.io/simapp/v2/simdv2/cmd"
 	stakingtypes "cosmossdk.io/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/client"
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
 	ced25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -37,6 +38,21 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	// HACK: add query flags to the root command that use insecure localhost grpc transport by default.
+	sdkflags.AddQueryFlagsToCmd = func(cmd *cobra.Command) {
+		cmd.Flags().String(sdkflags.FlagNode, "", "<host>:<port> to CometBFT RPC interface for this chain")
+		cmd.Flags().String(sdkflags.FlagGRPC, "localhost:9090", "the gRPC endpoint to use for this chain")
+		cmd.Flags().Bool(sdkflags.FlagGRPCInsecure, true, "allow gRPC over insecure channels, if not the server must use TLS")
+		cmd.Flags().Int64(sdkflags.FlagHeight, 0, "Use a specific height to query state at (this can error if the node is pruning state)")
+		cmd.Flags().StringP(sdkflags.FlagOutput, "o", "text", "Output format (text|json)")
+
+		// some base commands does not require chainID e.g `simd testnet` while subcommands do
+		// hence the flag should not be required for those commands
+		_ = cmd.MarkFlagRequired(sdkflags.FlagChainID)
+	}
+}
 
 // NewSimdRootCmdWithGordian calls a simdcmd function we have added
 // in order to get simd start to use Gordian instead of Comet.


### PR DESCRIPTION
SDK query flags default to localhost tendermint RPC transport, which of course does not exist. 
SDK does not expose the customizability of this via the autocli Builder, so this is a minimal hack to allow overriding the func at `init()`
Override query flags to default to insecure localhost grpc transport