### PR TITLE
fix: remove interactive key generation

### DIFF
--- a/scripts/run_gcosmos.sh
+++ b/scripts/run_gcosmos.sh
@@ -12,7 +12,7 @@ go build -o gcosmos .
 
 ./gcosmos init moniker --chain-id=${CHAIN_ID}
 
-./gcosmos keys add val
+./gcosmos keys add val --no-backup --keyring-backend=test
 ./gcosmos genesis add-genesis-account val 10000000stake
 ./gcosmos genesis gentx val 1000000stake --chain-id=${CHAIN_ID}
 ./gcosmos genesis collect-gentxs


### PR DESCRIPTION
This removes the need to interact with the key generation step within the `run_gcosmos.sh` script. Fixes 1 task in issue #3.

Possible bug: 
Just using the `--keyring-backend=test` still requires user interactions. However, on other cosmos chains, no user interactions are required with just that flag. The `--no-backup` flag ensures there are no user interactions, but the user will not be able to view the key's mnemonic outputted into the logs.