### PR TITLE
feat: simplify demo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build, setup, and start background gcosmos
       run: |
-        make install
+        make build
         make start &
 
     - name: Verify gcosmos is running

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,7 @@ jobs:
 
     - name: Build, setup, and start background gcosmos
       run: |
+        make install
         make start &
 
     - name: Verify gcosmos is running

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build, setup, and start background gcosmos
       run: |
-        ./scripts/run_gcosmos.sh &
+        make start &
 
     - name: Verify gcosmos is running
       run: |

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ install: deps
 	go install
 
 .PHONY: start
-start: install
+start: build
 	./scripts/run_gcosmos.sh

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ deps:
 build: deps
 	go build .
 	@echo >&2 executable saved to ./gcosmos
+
+.PHONY: install
+install: deps
+	go install
+
+.PHONY: start
+start: install
+	./scripts/run_gcosmos.sh

--- a/README.md
+++ b/README.md
@@ -3,71 +3,45 @@
 This repository integrates [Gordian](https://github.com/gordian-engine/gordian)
 with [the Cosmos SDK](https://github.com/cosmos/cosmos-sdk).
 
-## Setup
+## Quickstart
 
-We are currently using a local, patched clone of the SDK in tandem with Go workspaces.
-It is a bit unconventional to commit a Go workspace file, but while both Gordian and the Cosmos SDK
-are being actively changed, a fixed Go workspace fits well for now.
-
-From the root directory, run `make deps` to clone or fetch and checkout
-a "known working" version of the Cosmos SDK compatible with the current gcosmos tree,
-and then apply any currently necessary patches to the SDK.
-
-### New patches
-
-New patches to the SDK should build upon the existing patches,
-so long as the existing patches are necessary.
-
-To continue adding patches on top of the existing ones,
-the simplest workflow is:
-
-1. Ensure you are already synced via `make deps`
-2. Ensure you have the latest SDK commit, typically via `git fetch` inside the `_cosmosvendor/cosmos-sdk` directory.
-3. Rebase the existing patch set onto the latest commit, typically with `git rebase origin/main`. Address conflicts as needed.
-4. Optionally commit new code to your SDK checkout.
-4. From your new rebased set of patches, within the `_cosmosvendor/cosmos-sdk` directory,
-   run `git format-patch -o ../patches origin/main` to overwrite the existing set of patches with a new set that no longer has conflicts.
-5. Be sure to update `_cosmosvendor/COSMOS_SDK.commit`.
-6. Double check that running `_cosmosvendor/sync_sdk.bash` still results in passing tests.
-
-The set of SDK patches is minimal for now, and our goal is to depend on a tagged release of the SDK
-instead of having to maintain a patched version.
-
-## Running
-
-Begin running the updated simapp commands from the `gcosmos` directory.
+Start the example Gordian-backed Cosmos SDK chain with one validator
 
 ```bash
-sh ./scripts/run_gcosmos.sh
+CHAIN_ID=gchain-1 make start
 ```
 
 ### Interact
+
+In a second terminal, interact with the running chain
+
+Show validator address
+
 ```bash
-# Install the grpcurl binary in your relative directory to interact with the GRPC server.
-# GOBIN="$PWD" go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1
+VAL_ADDR=$(gcosmos keys show val --address)
+echo $VAL_ADDR
+```
 
-./grpcurl -plaintext localhost:9092 list
-./grpcurl -plaintext localhost:9092 gordian.server.v1.GordianGRPC/GetBlocksWatermark
-./grpcurl -plaintext localhost:9092 gordian.server.v1.GordianGRPC/GetValidators
-
-./grpcurl -plaintext -d '{"address":"cosmos1r5v5srda7xfth3hn2s26txvrcrntldjumt8mhl","denom":"stake"}' localhost:9092 gordian.server.v1.GordianGRPC/QueryAccountBalance
+Query bank balance of validator, it has `9000000stake`
+```bash
+gcosmos q bank balance $VAL_ADDR stake
 ```
 
 ### Transaction Testing
+
+Send `100stake` from the validator to a new account.
+
 ```bash
-./gcosmos tx bank send val cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn 1stake --chain-id=localchain-1 --generate-only > example-tx.json
-
-# TODO: get account number
-./gcosmos tx sign ./example-tx.json --offline --from=val --sequence=1 --account-number=0 --chain-id=localchain-1 --keyring-backend=test > example-tx-signed.json
-
-./grpcurl -plaintext -emit-defaults -d '{"tx":"'$(cat example-tx-signed.json | base64 | tr -d '\n')'"}' localhost:9092 gordian.server.v1.GordianGRPC/SimulateTransaction
-
-./grpcurl -plaintext -emit-defaults -d '{"tx":"'$(cat example-tx-signed.json | base64 | tr -d '\n')'"}' localhost:9092 gordian.server.v1.GordianGRPC/SubmitTransaction
-
-./grpcurl -plaintext -d '{"address":"cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn","denom":"stake"}' localhost:9092 gordian.server.v1.GordianGRPC/QueryAccountBalance
+gcosmos --chain-id gchain-1 tx bank send val cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn 100stake
 ```
 
-## Hacking on a demo with four validators
+Confirm the balance in the new account, it now has `100stake`
+
+```bash
+gcosmos q bank balance cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn stake
+```
+
+## Multiple validator example
 
 We have a current hack that uses a test setup with four validators,
 and then keeps them alive so that you can temporarily interact with the network.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ In a second terminal, interact with the running chain
 Show validator address
 
 ```bash
-VAL_ADDR=$(gcosmos keys show val --address)
+VAL_ADDR=$(./gcosmos keys show val --address)
 echo $VAL_ADDR
 ```
 
 Query bank balance of validator, it has `9000000stake`
 ```bash
-gcosmos q bank balance $VAL_ADDR stake
+./gcosmos q bank balance $VAL_ADDR stake
 ```
 
 ### Transaction Testing
@@ -32,13 +32,13 @@ gcosmos q bank balance $VAL_ADDR stake
 Send `100stake` from the validator to a new account.
 
 ```bash
-gcosmos --chain-id gchain-1 tx bank send val cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn 100stake
+./gcosmos --chain-id gchain-1 tx bank send val cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn 100stake
 ```
 
 Confirm the balance in the new account, it now has `100stake`
 
 ```bash
-gcosmos q bank balance cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn stake
+./gcosmos q bank balance cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn stake
 ```
 
 ## Multiple validator example

--- a/_cosmosvendor/README.md
+++ b/_cosmosvendor/README.md
@@ -7,3 +7,33 @@ This directory is special for development of the `gcosmos` module during these c
 3. The Gordian core repository has not yet been open sourced, so `gcosmos` is being developed as a nested module with `gordian`
 
 Once all of those points have been addressed, this directory will no longer be used.
+
+## Setup
+
+We are currently using a local, patched clone of the SDK in tandem with Go workspaces.
+It is a bit unconventional to commit a Go workspace file, but while both Gordian and the Cosmos SDK
+are being actively changed, a fixed Go workspace fits well for now.
+
+From the root directory, run `make deps` to clone or fetch and checkout
+a "known working" version of the Cosmos SDK compatible with the current gcosmos tree,
+and then apply any currently necessary patches to the SDK.
+
+### New patches
+
+New patches to the SDK should build upon the existing patches,
+so long as the existing patches are necessary.
+
+To continue adding patches on top of the existing ones,
+the simplest workflow is:
+
+1. Ensure you are already synced via `make deps` from the root of the repo.
+2. Ensure you have the latest SDK commit, typically via `git fetch` inside this `_cosmosvendor/cosmos-sdk` directory.
+3. Rebase the existing patch set onto the latest commit, typically with `git rebase origin/main`. Address conflicts as needed.
+4. Optionally commit new code to your SDK checkout.
+4. From your new rebased set of patches, within the `_cosmosvendor/cosmos-sdk` directory,
+   run `git format-patch -o ../patches origin/main` to overwrite the existing set of patches with a new set that no longer has conflicts.
+5. Be sure to update `_cosmosvendor/COSMOS_SDK.commit`.
+6. Double check that running `_cosmosvendor/sync_sdk.bash` still results in passing tests.
+
+The set of SDK patches is minimal for now, and our goal is to depend on a tagged release of the SDK
+instead of having to maintain a patched version.

--- a/_cosmosvendor/patches/0001-chore-use-cosmossdk.io-log-slog.patch
+++ b/_cosmosvendor/patches/0001-chore-use-cosmossdk.io-log-slog.patch
@@ -1,7 +1,7 @@
-From ed86e53dc20994a2a6b7b494a66a1c6e3dd69ea8 Mon Sep 17 00:00:00 2001
+From 350a5e27a2b3973d3795ec674895bcf8a7da19ec Mon Sep 17 00:00:00 2001
 From: Mark Rushakoff <mark@strange.love>
 Date: Fri, 25 Oct 2024 15:35:39 -0400
-Subject: [PATCH 1/2] chore: use cosmossdk.io/log/slog
+Subject: [PATCH 1/3] chore: use cosmossdk.io/log/slog
 
 We still need a way to correctly inject this into the config, but at
 least now we don't have to maintain a patch for an slog implementation.

--- a/_cosmosvendor/patches/0002-fix-allow-customizing-query-and-tx-flags.patch
+++ b/_cosmosvendor/patches/0002-fix-allow-customizing-query-and-tx-flags.patch
@@ -1,17 +1,26 @@
-From a8c0a22755d5f44fb2e328cfd1b4ee9202d6399d Mon Sep 17 00:00:00 2001
+From 9fcefeaab547f7ebb883d5a3127eea8420b04eea Mon Sep 17 00:00:00 2001
 From: Andrew Gouin <andrew@gouin.io>
 Date: Fri, 25 Oct 2024 16:25:31 -0600
-Subject: [PATCH 2/2] fix: allow customizing query and tx flags
+Subject: [PATCH 2/3] fix: allow customizing query and tx flags
 
 ---
- client/flags/flags.go | 52 ++++++++++++++++++++++++++++++++++++++-----
- 1 file changed, 46 insertions(+), 6 deletions(-)
+ client/flags/flags.go | 90 ++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 84 insertions(+), 6 deletions(-)
 
 diff --git a/client/flags/flags.go b/client/flags/flags.go
-index d44ed31679..41664664b1 100644
+index d44ed31679..14c798329e 100644
 --- a/client/flags/flags.go
 +++ b/client/flags/flags.go
-@@ -90,6 +90,10 @@ const (
+@@ -49,6 +49,8 @@ const (
+ 	FlagNode             = "node"
+ 	FlagGRPC             = "grpc-addr"
+ 	FlagGRPCInsecure     = "grpc-insecure"
++	FlagGRPCTx           = "grpc-addr-tx"
++	FlagGRPCInsecureTx   = "grpc-insecure-tx"
+ 	FlagHeight           = "height"
+ 	FlagGasAdjustment    = "gas-adjustment"
+ 	FlagFrom             = "from"
+@@ -90,6 +92,10 @@ const (
  	FlagLogLevel   = "log_level"
  	FlagLogFormat  = "log_format"
  	FlagLogNoColor = "log_no_color"
@@ -22,14 +31,20 @@ index d44ed31679..41664664b1 100644
  )
  
  // List of supported output formats
-@@ -98,23 +102,57 @@ const (
+@@ -98,23 +104,93 @@ const (
  	OutputFormatText = "text"
  )
  
-+// NodeFlagOpts defines customization options for command flags.
++// CmdNodeFlagOpts defines customization options for query and transaction command node flags.
++type CmdNodeFlagOpts struct {
++	QueryOpts *NodeFlagOpts
++	TxOpts    *NodeFlagOpts
++}
++
++// NodeFlagOpts defines customization options for node flags.
 +type NodeFlagOpts struct {
-+	// DefaultGRPC specifies whether GRPC should be used by default over RPC.
-+	DefaultGRPC bool
++	// DefaultGRPC, if defined, specifies the GRPC address which should be used by default over Comet RPC.
++	DefaultGRPC string
 +
 +	// AdditionalFlags specifies additional flags that should be added to the command.
 +	AdditionalFlags []*pflag.Flag
@@ -37,8 +52,7 @@ index d44ed31679..41664664b1 100644
 +
 +var (
 +	// App can override these default flag options
-+	QueryFlagOpts *NodeFlagOpts = nil
-+	TxFlagOpts    *NodeFlagOpts = nil
++	CliNodeFlagOpts *CmdNodeFlagOpts = nil
 +)
 +
  // LineBreak can be included in a command list to provide a blank line
@@ -53,7 +67,8 @@ index d44ed31679..41664664b1 100644
 -	cmd.Flags().Int64(FlagHeight, 0, "Use a specific height to query state at (this can error if the node is pruning state)")
 -	cmd.Flags().StringP(FlagOutput, "o", "text", "Output format (text|json)")
 +	f := cmd.Flags()
-+	AddNodeFlags(f, QueryFlagOpts)
++
++	AddNodeFlags(f, false)
 +
 +	f.Int64(FlagHeight, 0, "Use a specific height to query state at (this can error if the node is pruning state)")
 +	f.StringP(FlagOutput, "o", "text", "Output format (text|json)")
@@ -64,19 +79,49 @@ index d44ed31679..41664664b1 100644
  }
  
 +// AddNodeFlags adds common node network flags to a flag set.
-+func AddNodeFlags(f *pflag.FlagSet, opts *NodeFlagOpts) {
-+	if opts != nil && opts.DefaultGRPC {
-+		f.String(FlagNode, "", FlagNodeDesc)
-+		f.String(FlagGRPC, "localhost:9090", FlagGRPCDesc)
-+		f.Bool(FlagGRPCInsecure, true, FlagGRPCInsecureDesc)
-+	} else {
++func AddNodeFlags(f *pflag.FlagSet, tx bool) {
++	if CliNodeFlagOpts == nil {
 +		f.String(FlagNode, "tcp://localhost:26657", FlagNodeDesc)
 +		f.String(FlagGRPC, "", FlagGRPCDesc)
 +		f.Bool(FlagGRPCInsecure, false, FlagGRPCInsecureDesc)
++		return
 +	}
 +
-+	if opts != nil {
-+		for _, flag := range opts.AdditionalFlags {
++	qOpts, txOpts := CliNodeFlagOpts.QueryOpts, CliNodeFlagOpts.TxOpts
++
++	addDefaultCometRPCNodeFlag := false
++	if qOpts == nil || qOpts.DefaultGRPC == "" {
++		addDefaultCometRPCNodeFlag = true
++		f.String(FlagGRPC, "", FlagGRPCDesc)
++		f.Bool(FlagGRPCInsecure, false, FlagGRPCInsecureDesc)
++	} else {
++		f.String(FlagGRPC, qOpts.DefaultGRPC, FlagGRPCDesc)
++		f.Bool(FlagGRPCInsecure, true, FlagGRPCInsecureDesc)
++	}
++	if tx {
++		if txOpts == nil || txOpts.DefaultGRPC == "" {
++			addDefaultCometRPCNodeFlag = true
++			f.String(FlagGRPCTx, "", FlagGRPCDesc)
++			f.Bool(FlagGRPCInsecureTx, false, FlagGRPCInsecureDesc)
++		} else {
++			f.String(FlagGRPCTx, txOpts.DefaultGRPC, FlagGRPCDesc)
++			f.Bool(FlagGRPCInsecureTx, true, FlagGRPCInsecureDesc)
++		}
++	}
++	if addDefaultCometRPCNodeFlag {
++		f.String(FlagNode, "tcp://localhost:26657", FlagNodeDesc)
++	} else {
++		f.String(FlagNode, "", FlagNodeDesc)
++	}
++
++	if qOpts != nil {
++		for _, flag := range qOpts.AdditionalFlags {
++			f.AddFlag(flag)
++		}
++	}
++
++	if tx && txOpts != nil {
++		for _, flag := range txOpts.AdditionalFlags {
 +			f.AddFlag(flag)
 +		}
 +	}
@@ -85,13 +130,13 @@ index d44ed31679..41664664b1 100644
  // AddTxFlagsToCmd adds common flags to a module tx command.
  func AddTxFlagsToCmd(cmd *cobra.Command) {
  	f := cmd.Flags()
-@@ -127,7 +165,9 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
+@@ -127,7 +203,9 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
  	f.String(FlagNote, "", "Note to add a description to the transaction (previously --memo)")
  	f.String(FlagFees, "", "Fees to pay along with transaction; eg: 10uatom")
  	f.String(FlagGasPrices, "", "Determine the transaction fee by multiplying max gas units by gas prices (e.g. 0.1uatom), rounding up to nearest denom unit")
 -	f.String(FlagNode, "tcp://localhost:26657", "<host>:<port> to CometBFT rpc interface for this chain")
 +
-+	AddNodeFlags(f, TxFlagOpts)
++	AddNodeFlags(f, true)
 +
  	f.Bool(FlagUseLedger, false, "Use a connected Ledger device")
  	f.Float64(FlagGasAdjustment, DefaultGasAdjustment, "adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored ")

--- a/_cosmosvendor/patches/0003-hack-to-fix-height-not-passing-through-sdk-client-co.patch
+++ b/_cosmosvendor/patches/0003-hack-to-fix-height-not-passing-through-sdk-client-co.patch
@@ -1,0 +1,34 @@
+From abcb8e5e1c3c37d7a11ad4a5555cf2948d397831 Mon Sep 17 00:00:00 2001
+From: Andrew Gouin <andrew@gouin.io>
+Date: Sat, 26 Oct 2024 11:18:57 -0600
+Subject: [PATCH 3/3] hack to fix height not passing through sdk client context
+
+---
+ x/auth/types/account_retriever.go | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/x/auth/types/account_retriever.go b/x/auth/types/account_retriever.go
+index c46d433065..de59c9fc63 100644
+--- a/x/auth/types/account_retriever.go
++++ b/x/auth/types/account_retriever.go
+@@ -45,10 +45,16 @@ func (ar AccountRetriever) GetAccountWithHeight(clientCtx client.Context, addr s
+ 	}
+ 
+ 	blockHeight := header.Get(grpctypes.GRPCBlockHeightHeader)
+-	if l := len(blockHeight); l != 1 {
++	l := len(blockHeight)
++	if l > 1 {
+ 		return nil, 0, fmt.Errorf("unexpected '%s' header length; got %d, expected: %d", grpctypes.GRPCBlockHeightHeader, l, 1)
+ 	}
+ 
++	// TODO remove this once gordian height is propagated through the SDK properly
++	if l == 0 {
++		blockHeight = append(blockHeight, "0")
++	}
++
+ 	nBlockHeight, err := strconv.Atoi(blockHeight[0])
+ 	if err != nil {
+ 		return nil, 0, fmt.Errorf("failed to parse block height: %w", err)
+-- 
+2.47.0
+

--- a/gserver/cmtclient.go
+++ b/gserver/cmtclient.go
@@ -1,0 +1,193 @@
+package gserver
+
+import (
+	"context"
+	"fmt"
+
+	cmtcryptoed25519 "github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/libs/bytes"
+	cmtclient "github.com/cometbft/cometbft/rpc/client"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	client "github.com/cosmos/cosmos-sdk/client"
+	ggrpc "github.com/gordian-engine/gcosmos/gserver/internal/ggrpc"
+	"github.com/spf13/cobra"
+	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var _ client.CometRPC = (*Client)(nil)
+
+type Client struct {
+	cmd     *cobra.Command
+	gclient ggrpc.GordianGRPCClient
+}
+
+func NewClient(
+	cmd *cobra.Command,
+	grpcAddress string,
+	grpcInsecure bool,
+) (*Client, error) {
+	var dialOpts []grpc.DialOption
+	if grpcInsecure {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	cc, err := grpc.NewClient(grpcAddress, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial gRPC: %w", err)
+	}
+
+	return &Client{
+		cmd:     cmd,
+		gclient: ggrpc.NewGordianGRPCClient(cc),
+	}, nil
+}
+
+func (c *Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) ABCIQueryWithOptions(ctx context.Context, path string, data bytes.HexBytes, opts cmtclient.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) BroadcastTxAsync(ctx context.Context, tx cmttypes.Tx) (*coretypes.ResultBroadcastTx, error) {
+	// TODO implement
+	return c.BroadcastTxSync(ctx, tx)
+}
+
+func (c *Client) BroadcastTxCommit(ctx context.Context, tx cmttypes.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (c *Client) BroadcastTxSync(ctx context.Context, tx cmttypes.Tx) (*coretypes.ResultBroadcastTx, error) {
+	clientCtx, err := client.GetClientTxContext(c.cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client tx context: %w", err)
+	}
+
+	sdkTx, err := clientCtx.TxConfig.TxDecoder()(tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode tx: %w", err)
+	}
+
+	txJson, err := clientCtx.TxConfig.TxJSONEncoder()(sdkTx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode tx: %w", err)
+	}
+
+	res, err := c.gclient.SimulateTransaction(ctx, &ggrpc.SubmitSimulationTransactionRequest{
+		Tx: txJson,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to simulate transaction: %w", err)
+	}
+	if res.Error != "" {
+		return nil, fmt.Errorf("failed to simulate transaction: %s", res.Error)
+	}
+
+	res, err = c.gclient.SubmitTransaction(ctx, &ggrpc.SubmitTransactionRequest{
+		Tx: txJson,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to submit transaction: %w", err)
+	}
+	if res.Error != "" {
+		return nil, fmt.Errorf("failed to submit transaction: %s", res.Error)
+	}
+
+	return &coretypes.ResultBroadcastTx{
+		Code:      res.Code,
+		Data:      res.Data,
+		Log:       res.Log,
+		Hash:      tx.Hash(),
+		Codespace: res.Codespace,
+	}, nil
+}
+
+func (c *Client) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
+	valsRes, err := c.gclient.GetValidators(ctx, &ggrpc.GetValidatorsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validators: %w", err)
+	}
+
+	vals := valsRes.Validators
+
+	res := &coretypes.ResultValidators{
+		BlockHeight: 0, // TODO
+		Validators:  make([]*cmttypes.Validator, len(vals)),
+		Count:       len(vals), // no pagination yet
+		Total:       len(vals),
+	}
+
+	for i, val := range vals {
+		res.Validators[i] = &cmttypes.Validator{
+			// Address: // TODO derive from pubkey
+			PubKey:      cmtcryptoed25519.PubKey(val.GetEncodedPubKey()), // TODO may need to decode based on method name
+			VotingPower: int64(val.Power),
+		}
+	}
+
+	return res, nil
+}
+
+func (c *Client) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
+	gRes, err := c.gclient.GetBlocksWatermark(ctx, &ggrpc.CurrentBlockRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blocks watermark: %w", err)
+	}
+
+	// TODO fill out remaining fields
+	return &coretypes.ResultStatus{
+		SyncInfo: coretypes.SyncInfo{
+			LatestBlockHeight: int64(gRes.CommittingHeight) - 1,
+		},
+	}, nil
+}
+
+func (c *Client) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) BlockByHash(ctx context.Context, hash []byte) (*coretypes.ResultBlock, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) Tx(ctx context.Context, hash []byte, prove bool) (*coretypes.ResultTx, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) TxSearch(
+	ctx context.Context,
+	query string,
+	prove bool,
+	page, perPage *int,
+	orderBy string,
+) (*coretypes.ResultTxSearch, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (c *Client) BlockSearch(
+	ctx context.Context,
+	query string,
+	page, perPage *int,
+	orderBy string,
+) (*coretypes.ResultBlockSearch, error) {
+	panic(fmt.Errorf("not implemented"))
+}

--- a/gserver/cmtclient.go
+++ b/gserver/cmtclient.go
@@ -87,7 +87,7 @@ func (c *Client) BroadcastTxSync(ctx context.Context, tx cmttypes.Tx) (*coretype
 		return nil, fmt.Errorf("failed to simulate transaction: %w", err)
 	}
 	if res.Error != "" {
-		return nil, fmt.Errorf("failed to simulate transaction: %s", res.Error)
+		return nil, fmt.Errorf("failure expecting simulated transaction: %s", res.Error)
 	}
 
 	res, err = c.gclient.SubmitTransaction(ctx, &ggrpc.SubmitTransactionRequest{
@@ -97,7 +97,7 @@ func (c *Client) BroadcastTxSync(ctx context.Context, tx cmttypes.Tx) (*coretype
 		return nil, fmt.Errorf("failed to submit transaction: %w", err)
 	}
 	if res.Error != "" {
-		return nil, fmt.Errorf("failed to submit transaction: %s", res.Error)
+		return nil, fmt.Errorf("failure expecting transaction: %s", res.Error)
 	}
 
 	return &coretypes.ResultBroadcastTx{

--- a/scripts/run_gcosmos.sh
+++ b/scripts/run_gcosmos.sh
@@ -7,14 +7,11 @@ G_GRPC_ADDR=${G_GRPC_ADDR:-"9092"}
 # cleanup previous run data as gordian can only start from height 0 currently
 rm -rf ~/.simappv2/
 
-echo "Building gcosmos binary..."
-go build -o gcosmos .
+gcosmos init moniker --chain-id=${CHAIN_ID}
 
-./gcosmos init moniker --chain-id=${CHAIN_ID}
+gcosmos keys add val --no-backup --keyring-backend=test
+gcosmos genesis add-genesis-account val 10000000stake
+gcosmos genesis gentx val 1000000stake --chain-id=${CHAIN_ID}
+gcosmos genesis collect-gentxs
 
-./gcosmos keys add val --no-backup --keyring-backend=test
-./gcosmos genesis add-genesis-account val 10000000stake
-./gcosmos genesis gentx val 1000000stake --chain-id=${CHAIN_ID}
-./gcosmos genesis collect-gentxs
-
-./gcosmos start --g-http-addr 127.0.0.1:$G_HTTP_ADDR --g-grpc-addr 127.0.0.1:$G_GRPC_ADDR
+gcosmos start --g-http-addr 127.0.0.1:$G_HTTP_ADDR --g-grpc-addr 127.0.0.1:$G_GRPC_ADDR

--- a/scripts/run_gcosmos.sh
+++ b/scripts/run_gcosmos.sh
@@ -7,11 +7,11 @@ G_GRPC_ADDR=${G_GRPC_ADDR:-"9092"}
 # cleanup previous run data as gordian can only start from height 0 currently
 rm -rf ~/.simappv2/
 
-gcosmos init moniker --chain-id=${CHAIN_ID}
+./gcosmos init moniker --chain-id=${CHAIN_ID}
 
-gcosmos keys add val --no-backup --keyring-backend=test
-gcosmos genesis add-genesis-account val 10000000stake
-gcosmos genesis gentx val 1000000stake --chain-id=${CHAIN_ID}
-gcosmos genesis collect-gentxs
+./gcosmos keys add val --no-backup --keyring-backend=test
+./gcosmos genesis add-genesis-account val 10000000stake
+./gcosmos genesis gentx val 1000000stake --chain-id=${CHAIN_ID}
+./gcosmos genesis collect-gentxs
 
-gcosmos start --g-http-addr 127.0.0.1:$G_HTTP_ADDR --g-grpc-addr 127.0.0.1:$G_GRPC_ADDR
+./gcosmos start --g-http-addr 127.0.0.1:$G_HTTP_ADDR --g-grpc-addr 127.0.0.1:$G_GRPC_ADDR


### PR DESCRIPTION
demo can now be run with a minimal set of commands, running directly through the `gcosmos` binary

## Quickstart

Start the example Gordian-backed Cosmos SDK chain with one validator

```bash
CHAIN_ID=gchain-1 make start
```

### Interact

In a second terminal, interact with the running chain

Show validator address

```bash
VAL_ADDR=$(gcosmos keys show val --address)
echo $VAL_ADDR
```

Query bank balance of validator, it has `9000000stake`
```bash
gcosmos q bank balance $VAL_ADDR stake
```

### Transaction Testing

Send `100stake` from the validator to a new account.

```bash
gcosmos --chain-id gchain-1 tx bank send val cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn 100stake
```

Confirm the balance in the new account, it now has `100stake`

```bash
gcosmos q bank balance cosmos10r39fueph9fq7a6lgswu4zdsg8t3gxlqvvvyvn stake
```

TODO for follow-on: client query context needs to be able to fetch the chain latest height to remove the cosmos-sdk 0003 patch

Resolves #2 