### PR TITLE
fix: main test single delegate

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
     tags:
     - '**'
     branches:
-    - '**'
+    - main
 
 env:
   GORDIAN_TEST_TIME_FACTOR: 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     tags:
     - '**'
     branches:
-    - '**'
+    - main
 
 jobs:
   build:

--- a/main_test.go
+++ b/main_test.go
@@ -533,7 +533,7 @@ func TestTx_single_delegate(t *testing.T) {
 		res := c.RootCmds[0].Run(
 			// val0 is the name of the first validator key,
 			// which should be available on the first root command.
-			"tx", "staking", "delegate", "val0", delegateAmount, "--from", c.FixedAddresses[0],
+			"tx", "--chain-id", t.Name(), "staking", "delegate", "val0", delegateAmount, "--from", c.FixedAddresses[0],
 			"--generate-only",
 		)
 		res.NoError(t)


### PR DESCRIPTION
`tx` commands require `--chain-id`. This really shouldn't be required for `--generate-only` since the `--chain-id` is only used during signing, but fixes the issue.

Also updates CI so that test and build jobs only run once per branch push for PRs.