### PR TITLE
fix: dedupe ci jobs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
     tags:
     - '**'
     branches:
-    - '**'
+    - main
 
 env:
   GORDIAN_TEST_TIME_FACTOR: 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     tags:
     - '**'
     branches:
-    - '**'
+    - main
 
 jobs:
   build:


### PR DESCRIPTION
Fix integration and test jobs running twice per push on PRs.